### PR TITLE
Add filename as the test name when yielding files

### DIFF
--- a/src/DataProvider/StaticFixtureFinder.php
+++ b/src/DataProvider/StaticFixtureFinder.php
@@ -16,7 +16,7 @@ final class StaticFixtureFinder
         $fileInfos = self::findFilesInDirectory($directory, $suffix);
 
         foreach ($fileInfos as $fileInfo) {
-            yield [new SmartFileInfo($fileInfo->getRealPath())];
+            yield $fileInfo->getFilename() => [new SmartFileInfo($fileInfo->getRealPath())];
         }
     }
 


### PR DESCRIPTION
This gives a much clearer image of what test file that fails, as the test name itself contains the filename.